### PR TITLE
Remove unnecessary appComponentFactory override

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/AndroidManifest.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/AndroidManifest.xml
@@ -6,8 +6,6 @@
     <!--<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>-->
 
     <application
-        tools:replace="android:appComponentFactory"
-        android:appComponentFactory="androidx.core.app.CoreComponentFactory"
         android:networkSecurityConfig="@xml/network_security_config"
         android:screenOrientation="portrait"
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- remove obsolete `tools:replace` and `android:appComponentFactory` from Insurance module manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy (HTTP/1.1 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68b741f9518c832a918f01ff967628fd