### PR TITLE
Fix Hilt compiler setup and Gradle JDK path

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     // Hilt
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
+    kapt("androidx.hilt:hilt-compiler:1.1.0")
 
     // Navigation
     implementation(libs.navigation.fragment.ktx)

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/gradle.properties
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/gradle.properties
@@ -17,7 +17,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-17.0.16.8-hotspot.
+# Use system installed JDK instead of a hardcoded Windows path
+# org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-17.0.16.8-hotspot.
 # Enables namespacing of each library's R class so that its R class includes only the
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library


### PR DESCRIPTION
## Summary
- add explicit `androidx.hilt` compiler dependency for Insurance module
- remove invalid Gradle `org.gradle.java.home` path

## Testing
- `./gradlew :XIvan:Library:Insurance:kaptDebugKotlin --stacktrace --info` *(fails: Unable to tunnel through proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b74362bbac832ab0810fc358067bee