### PR TITLE
Prefix bearer token when fetching policies

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
@@ -3,6 +3,7 @@ package com.cursosant.insurance.policiesModule.model
 import com.cursosant.insurance.common.dataAccess.MiuraboxService
 import com.cursosant.insurance.common.dataAccess.UserService
 import com.cursosant.insurance.common.entities.Policy
+import com.cursosant.insurance.common.utils.Constants
 import javax.inject.Inject
 
 /****
@@ -21,7 +22,7 @@ import javax.inject.Inject
  ***/
 class DataSource @Inject constructor(private val service: MiuraboxService) {
     suspend fun getPolicies(token: String): List<Policy>{
-        return service.getPoliciesByUser(token)
+        return service.getPoliciesByUser("${Constants.H_BEARER}$token")
         /*return try {
             val result = service.getPoliciesByUser(token)
             result


### PR DESCRIPTION
## Summary
- prefix policy retrieval call with bearer token header

## Testing
- `./gradlew :XIvan:Library:Insurance:assemble` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*
- `curl -s -o /tmp/policies.json -w "%{http_code}\n" -H "Authorization: Bearer dummy" https://api.miurabox.com/poliza-by-user-app/` *(connection failed: HTTP status 000)*

------
https://chatgpt.com/codex/tasks/task_e_68b771ae09b4832a9ffb93598ecf18af