### PR TITLE
Hide quote menu item

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/res/menu/activity_main_drawer_custom.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/res/menu/activity_main_drawer_custom.xml
@@ -20,7 +20,7 @@
             android:id="@+id/nav_quote"
             android:icon="@drawable/ic_request_quote"
             android:title="@string/home_btn_quote"
-            android:visible="true"/>
+            android:visible="false"/>
         <item
             android:id="@+id/nav_insurers"
             android:icon="@drawable/ic_playlist_add_check_circle"


### PR DESCRIPTION
## Summary
- hide Quote screen from the navigation drawer until the module is ready

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bc0acb78832a8ae49164500bbe50