### PR TITLE
Hide quote entry points and show registration success

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/view/RegisterFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/view/RegisterFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -14,6 +15,7 @@ import com.cursosant.insurance.common.utils.UiUtils
 import com.cursosant.insurance.common.utils.Utils
 import com.cursosant.insurance.databinding.FragmentRegisterBinding
 import com.cursosant.insurance.registerModule.viewModel.RegisterViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -43,6 +45,7 @@ open class RegisterFragment : Fragment() {
 
     private var _binding: FragmentRegisterBinding? = null
     private val binding get() = _binding!!
+    private var successDialog: AlertDialog? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentRegisterBinding.inflate(inflater, container, false)
@@ -70,6 +73,11 @@ open class RegisterFragment : Fragment() {
             }
             vm.snackbarWarning.observe(viewLifecycleOwner) { resMsg ->
                 uiUtils.snackbarWarning(binding.root, resMsg)
+            }
+            vm.showSuccessDialog.observe(viewLifecycleOwner) { shouldShow ->
+                if (shouldShow == true) {
+                    showRegisterSuccessDialog()
+                }
             }
             vm.isHideKeyboard.observe(viewLifecycleOwner) { isHide ->
                 if (isHide) uiUtils.hideKeyboard(binding.root)
@@ -134,6 +142,8 @@ open class RegisterFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        successDialog?.dismiss()
+        successDialog = null
         _binding = null
     }
 
@@ -166,5 +176,25 @@ open class RegisterFragment : Fragment() {
             tilPasswordConfirm.hintTextColor = colorState
             tilPasswordConfirm.boxStrokeColor = color
         }
+    }
+
+    private fun showRegisterSuccessDialog() {
+        val currentBinding = _binding ?: return
+        if (successDialog?.isShowing == true) return
+
+        successDialog = MaterialAlertDialogBuilder(currentBinding.root.context)
+            .setTitle(R.string.register_success_title)
+            .setMessage(R.string.register_user_created)
+            .setPositiveButton(R.string.ok) { dialog, _ ->
+                dialog.dismiss()
+                currentBinding.viewModel?.onSuccessDialogConsumed()
+                navUtils.run { navController.navigate(actionRegisterToLogin) }
+            }
+            .setOnDismissListener {
+                currentBinding.viewModel?.onSuccessDialogConsumed()
+                successDialog = null
+            }
+            .setCancelable(false)
+            .show()
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
@@ -32,11 +32,19 @@ class RegisterViewModel @Inject constructor(
     private val _registerResult = MutableLiveData<RegisterResponse>()
     val registerResult: LiveData<RegisterResponse> = _registerResult
 
+    private val _showSuccessDialog = MutableLiveData<Boolean>()
+    val showSuccessDialog: LiveData<Boolean> = _showSuccessDialog
+
     fun register(first: String, last: String, email: String, pass: String) {
         executeAction {
             repository.register(first, last, email, pass) { result ->
                 _registerResult.postValue(result)
+                _showSuccessDialog.postValue(true)
             }
         }
+    }
+
+    fun onSuccessDialogConsumed() {
+        _showSuccessDialog.value = false
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/strings.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="notifications_empty_msg">No hay notificaciones</string>
 
     <string name="register_error">El email ya existe.</string>
+    <string name="register_success_title">Registro exitoso</string>
     <string name="register_user_created">Usuario creado exitosamente, para inicar sesión le hemos enviado un correo de activación.</string>
     <string name="register_empty_email">Ingresa un correo electrónico</string>
     <string name="register_empty_password_confirm">Confirma la contraseña</string>

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/java/com/miurabox/ega/mexico/HomeFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/java/com/miurabox/ega/mexico/HomeFragment.kt
@@ -23,6 +23,5 @@ class HomeFragment : HomeFragment() {
         super.onStart()
         setImgCover(R.drawable.fondo_menu)
         setBackgroundColor(R.color.color_custom_background)
-        showQuoter()
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/res/menu/activity_main_drawer_custom.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/res/menu/activity_main_drawer_custom.xml
@@ -20,7 +20,7 @@
             android:id="@+id/nav_quote"
             android:icon="@drawable/ic_request_quote"
             android:title="@string/home_btn_quote"
-            android:visible="true"/>
+            android:visible="false"/>
         <item
             android:id="@+id/nav_insurers"
             android:icon="@drawable/ic_playlist_add_check_circle"


### PR DESCRIPTION
## Summary
- hide Quote screen from the navigation drawer until the module is ready
- remove call that displayed the Quote button on the home screen
- show a modal success dialog after registration and return to the login screen once it is acknowledged

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b9bc0acb78832a8ae49164500bbe50