### PR TITLE
Fix duplicate LiveData declarations in RegisterViewModel

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
@@ -37,9 +37,6 @@ class RegisterViewModel @Inject constructor(
     private val _navigateToLogin = MutableLiveData<Boolean>()
     val navigateToLogin: LiveData<Boolean> = _navigateToLogin
 
-    private val _showSuccessDialog = MutableLiveData<Boolean>()
-    val showSuccessDialog: LiveData<Boolean> = _showSuccessDialog
-
     fun register(first: String, last: String, email: String, pass: String) {
         executeAction {
             repository.register(first, last, email, pass) { result ->


### PR DESCRIPTION
## Summary
- remove duplicate `showSuccessDialog` LiveData properties from `RegisterViewModel`

## Testing
- bash ./gradlew :app:compileDebugKotlin *(fails: Unable to download Gradle distribution due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d2baef3c48832ab2d021b34ba17b7e