### PR TITLE
Align register success alert with email notification style

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
@@ -37,16 +37,13 @@ class RegisterViewModel @Inject constructor(
     private val _navigateToLogin = MutableLiveData<Boolean>()
     val navigateToLogin: LiveData<Boolean> = _navigateToLogin
 
-    private val _showSuccessDialog = MutableLiveData<Boolean>()
-    val showSuccessDialog: LiveData<Boolean> = _showSuccessDialog
-
     fun register(first: String, last: String, email: String, pass: String) {
         executeAction {
             repository.register(first, last, email, pass) { result ->
                 when (result) {
                     is RegisterResult.Success -> {
                         _registerResult.postValue(result)
-                        showMsg(R.string.register_user_created)
+                        showWarning(R.string.register_user_created)
                         _showSuccessDialog.postValue(true)
                     }
                     RegisterResult.AlreadyRegisteredInactive -> {


### PR DESCRIPTION
## Summary
- switch the registration success message to use the warning snackbar so it matches the email notification alerts

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d2baef3c48832ab2d021b34ba17b7e