### PR TITLE
Show registration feedback only in dialogs

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/view/RegisterFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/view/RegisterFragment.kt
@@ -14,6 +14,7 @@ import com.cursosant.insurance.common.utils.NavUtils
 import com.cursosant.insurance.common.utils.UiUtils
 import com.cursosant.insurance.common.utils.Utils
 import com.cursosant.insurance.databinding.FragmentRegisterBinding
+import com.cursosant.insurance.registerModule.viewModel.RegisterDialogConfig
 import com.cursosant.insurance.registerModule.viewModel.RegisterViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
@@ -45,7 +46,7 @@ open class RegisterFragment : Fragment() {
 
     private var _binding: FragmentRegisterBinding? = null
     private val binding get() = _binding!!
-    private var successDialog: AlertDialog? = null
+    private var messageDialog: AlertDialog? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentRegisterBinding.inflate(inflater, container, false)
@@ -74,16 +75,8 @@ open class RegisterFragment : Fragment() {
             vm.snackbarWarning.observe(viewLifecycleOwner) { resMsg ->
                 uiUtils.snackbarWarning(binding.root, resMsg)
             }
-            vm.showSuccessDialog.observe(viewLifecycleOwner) { shouldShow ->
-                if (shouldShow == true) {
-                    showRegisterSuccessDialog()
-                }
-            }
-            vm.navigateToLogin.observe(viewLifecycleOwner) { shouldNavigate ->
-                if (shouldNavigate == true) {
-                    navUtils.run { navController.navigate(actionRegisterToLogin) }
-                    vm.onNavigatedToLogin()
-                }
+            vm.dialogConfig.observe(viewLifecycleOwner) { config ->
+                config?.let { showRegisterDialog(it) }
             }
 
             vm.isHideKeyboard.observe(viewLifecycleOwner) { isHide ->
@@ -149,8 +142,8 @@ open class RegisterFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        successDialog?.dismiss()
-        successDialog = null
+        messageDialog?.dismiss()
+        messageDialog = null
         _binding = null
     }
 
@@ -185,21 +178,22 @@ open class RegisterFragment : Fragment() {
         }
     }
 
-    private fun showRegisterSuccessDialog() {
+    private fun showRegisterDialog(config: RegisterDialogConfig) {
         val currentBinding = _binding ?: return
-        if (successDialog?.isShowing == true) return
+        if (messageDialog?.isShowing == true) return
 
-        successDialog = MaterialAlertDialogBuilder(currentBinding.root.context)
-            .setTitle(R.string.register_success_title)
-            .setMessage(R.string.register_user_created)
+        messageDialog = MaterialAlertDialogBuilder(currentBinding.root.context)
+            .setTitle(config.titleRes)
+            .setMessage(config.messageRes)
             .setPositiveButton(R.string.ok) { dialog, _ ->
                 dialog.dismiss()
-                currentBinding.viewModel?.onSuccessDialogConsumed()
-                navUtils.run { navController.navigate(actionRegisterToLogin) }
             }
             .setOnDismissListener {
-                currentBinding.viewModel?.onSuccessDialogConsumed()
-                successDialog = null
+                currentBinding.viewModel?.onDialogConsumed()
+                messageDialog = null
+                if (config.navigateToLogin) {
+                    navUtils.run { navController.navigate(actionRegisterToLogin) }
+                }
             }
             .setCancelable(false)
             .show()

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/registerModule/viewModel/RegisterViewModel.kt
@@ -1,5 +1,6 @@
 package com.cursosant.insurance.registerModule.viewModel
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.cursosant.insurance.R
@@ -31,11 +32,8 @@ class RegisterViewModel @Inject constructor(
     private val _registerResult = MutableLiveData<RegisterResult.Success>()
     val registerResult: LiveData<RegisterResult.Success> = _registerResult
 
-    private val _showSuccessDialog = MutableLiveData<Boolean>()
-    val showSuccessDialog: LiveData<Boolean> = _showSuccessDialog
-
-    private val _navigateToLogin = MutableLiveData<Boolean>()
-    val navigateToLogin: LiveData<Boolean> = _navigateToLogin
+    private val _dialogConfig = MutableLiveData<RegisterDialogConfig?>()
+    val dialogConfig: LiveData<RegisterDialogConfig?> = _dialogConfig
 
     fun register(first: String, last: String, email: String, pass: String) {
         executeAction {
@@ -43,15 +41,31 @@ class RegisterViewModel @Inject constructor(
                 when (result) {
                     is RegisterResult.Success -> {
                         _registerResult.postValue(result)
-                        showWarning(R.string.register_user_created)
-                        _showSuccessDialog.postValue(true)
+                        _dialogConfig.postValue(
+                            RegisterDialogConfig(
+                                titleRes = R.string.register_success_title,
+                                messageRes = R.string.register_user_created,
+                                navigateToLogin = true
+                            )
+                        )
                     }
                     RegisterResult.AlreadyRegisteredInactive -> {
-                        showWarning(R.string.register_user_exists_inactive)
+                        _dialogConfig.postValue(
+                            RegisterDialogConfig(
+                                titleRes = R.string.dialog_warning_title,
+                                messageRes = R.string.register_user_exists_inactive,
+                                navigateToLogin = false
+                            )
+                        )
                     }
                     RegisterResult.AlreadyRegisteredActive -> {
-                        showMsg(R.string.register_user_already_active)
-                        _navigateToLogin.postValue(true)
+                        _dialogConfig.postValue(
+                            RegisterDialogConfig(
+                                titleRes = R.string.dialog_warning_title,
+                                messageRes = R.string.register_user_already_active,
+                                navigateToLogin = true
+                            )
+                        )
                     }
                 }
 
@@ -59,12 +73,14 @@ class RegisterViewModel @Inject constructor(
         }
     }
 
-    fun onSuccessDialogConsumed() {
-        _showSuccessDialog.value = false
-    }
-
-    fun onNavigatedToLogin() {
-        _navigateToLogin.value = false
+    fun onDialogConsumed() {
+        _dialogConfig.value = null
     }
 
 }
+
+data class RegisterDialogConfig(
+    @StringRes val titleRes: Int,
+    @StringRes val messageRes: Int,
+    val navigateToLogin: Boolean
+)


### PR DESCRIPTION
## Summary
- show registration outcomes through a single dialog configuration emitted by the view model
- update the registration fragment to render feedback messages with MaterialAlertDialog and navigate after dismissal when needed

## Testing
- `bash gradlew :app:assembleDebug` *(fails: Unable to download Gradle distribution because of proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c9a7ed3c832aa17c8b091a129ffe