### PR TITLE
Add paging dependency for insurance module

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
 
+    // Paging
+    implementation("androidx.paging:paging-runtime-ktx:3.2.1")
+
     // Retrofit + OkHttp
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")


### PR DESCRIPTION
## Summary
- add the AndroidX Paging runtime dependency to the Insurance library module so PagingSource resolves correctly

## Testing
- ./gradlew :XIvan:Library:Insurance:compileDebugKotlin *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68efdc9023bc832a9c83f63287840d1d