### PR TITLE
Fix policies pagination data flow

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
 
+    // Paging
+    implementation("androidx.paging:paging-runtime-ktx:3.2.1")
+
     // Retrofit + OkHttp
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/dataAccess/MiuraboxService.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/dataAccess/MiuraboxService.kt
@@ -6,11 +6,11 @@ import com.cursosant.insurance.common.entities.Insurance
 import com.cursosant.insurance.common.entities.NotificationResponse
 import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.entities.PolicyDetail
-import com.cursosant.insurance.common.entities.PoliciesPage
 import com.cursosant.insurance.common.entities.SinisterResponse
 import com.cursosant.insurance.common.entities.AncoraDocsResponse
 import com.cursosant.insurance.common.entities.BaseResponse
 import com.cursosant.insurance.common.utils.Constants
+import com.cursosant.insurance.policiesModule.model.PolicyPagedResponse
 import retrofit2.http.FieldMap
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
@@ -24,8 +24,9 @@ interface MiuraboxService {
     @GET(Constants.PATH_POLICIES)
     suspend fun getPoliciesPageByUser(
         @Header(Constants.H_AUTHORIZATION) token: String,
-        @Query("page") page: Int? = null
-    ) : PoliciesPage
+        @Query("page") page: Int? = null,
+        @Query("page_size") pageSize: Int? = null
+    ) : PolicyPagedResponse
 
     @GET(Constants.PATH_POLICIES + "{${Constants.P_USERNAME}}")
     suspend fun getPoliciesInUser(

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
@@ -77,6 +77,7 @@ object Constants {
     const val V_URL_NAME = "grupoasapi"
     const val P_ORGANIZATION = "org"
     const val V_ORGANIZATION = "pruebas"
+    const val P_PAGE = "page"
     //Contact
     const val P_CONTACT_NAME = "from_name"
     const val P_CONTACT_EMAIL = "from_email"

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
@@ -1,8 +1,6 @@
 package com.cursosant.insurance.policiesModule.model
 
 import com.cursosant.insurance.common.dataAccess.MiuraboxService
-import com.cursosant.insurance.common.entities.PoliciesPage
-import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.utils.Constants
 import javax.inject.Inject
 
@@ -22,11 +20,11 @@ import javax.inject.Inject
  ***/
 class DataSource @Inject constructor(private val service: MiuraboxService) {
 
-    suspend fun getPolicies(token: String): List<Policy> {
-        return getPoliciesPage(token, null).policies
-    }
-
-    suspend fun getPoliciesPage(token: String, page: Int?): PoliciesPage {
-        return service.getPoliciesPageByUser("${Constants.H_BEARER}$token", page)
+    suspend fun getPolicies(
+        token: String,
+        page: Int?,
+        pageSize: Int?
+    ): PolicyPagedResponse {
+        return service.getPoliciesPageByUser("${Constants.H_BEARER}$token", page, pageSize)
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
@@ -1,7 +1,6 @@
 package com.cursosant.insurance.policiesModule.model
 
 import com.cursosant.insurance.common.entities.InsuranceException
-import com.cursosant.insurance.common.entities.PoliciesPage
 import com.cursosant.insurance.common.model.BaseRepository
 import com.cursosant.insurance.common.utils.TypeError
 import kotlinx.coroutines.Dispatchers
@@ -23,10 +22,10 @@ import javax.inject.Inject
  * www.alainnicolastello.com
  ***/
 class PoliciesRepository @Inject constructor(private val dataSource: DataSource) : BaseRepository() {
-    suspend fun getPolicies(token: String, page: Int?): PoliciesPage =
+    suspend fun getPolicies(token: String, page: Int?, pageSize: Int? = null): PolicyPagedResponse =
         withContext(Dispatchers.IO) {
-            executeAction<PoliciesPage>(InsuranceException(TypeError.POLICIES)) {
-                dataSource.getPoliciesPage(token, page)
+            executeAction<PolicyPagedResponse>(InsuranceException(TypeError.POLICIES)) {
+                dataSource.getPolicies(token, page, pageSize)
             }
         }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
@@ -4,10 +4,10 @@ import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.cursosant.insurance.common.entities.InsuranceException
-import com.cursosant.insurance.common.entities.PoliciesPage
 import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.viewModel.BaseViewModel
 import com.cursosant.insurance.policiesModule.model.PoliciesRepository
+import com.cursosant.insurance.policiesModule.model.PolicyPagedResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -74,7 +74,7 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
         executeAction {
             try {
                 val result = repository.getPolicies(token, page)
-                updatePolicies(result.policies)
+                updatePolicies(result.results.orEmpty())
                 updatePaginationState(result, page)
             } catch (exception: InsuranceException) {
                 _canGoNext.postValue(previousNextState ?: false)
@@ -100,11 +100,12 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
         _policies.postValue(policies)
     }
 
-    private fun updatePaginationState(page: PoliciesPage, requestedPage: Int) {
+    private fun updatePaginationState(page: PolicyPagedResponse, requestedPage: Int) {
         currentPage = requestedPage
         totalCount = page.count
-        if (pageSize == null && page.policies.isNotEmpty()) {
-            pageSize = page.policies.size
+        val results = page.results.orEmpty()
+        if (pageSize == null && results.isNotEmpty()) {
+            pageSize = results.size
         }
 
         nextPage = extractPageNumber(page.next)
@@ -113,7 +114,7 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
         _canGoNext.postValue(nextPage != null)
         _canGoPrevious.postValue(previousPage != null)
 
-        val hasPolicies = page.policies.isNotEmpty()
+        val hasPolicies = results.isNotEmpty()
         val hasCount = hasTotalCount()
         val hasNavigation = nextPage != null || previousPage != null
         val shouldShowIndicator = hasPolicies || hasCount || hasNavigation


### PR DESCRIPTION
## Summary
- update the Miurabox service contract to return the paginated policy payload including optional page size
- adjust the policies data source, repository, and view model to consume PolicyPagedResponse data and derive UI state
- add the missing Constants.P_PAGE entry for parsing pagination links

## Testing
- ./gradlew :XIvan:Library:Insurance:compileDebugKotlin *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68efdc9023bc832a9c83f63287840d1d