### PR TITLE
Initialize policies ads safely

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
 
+    // Paging
+    implementation("androidx.paging:paging-runtime-ktx:3.2.1")
+
     // Retrofit + OkHttp
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
@@ -93,6 +96,9 @@ dependencies {
     // Firebase Messaging (FCM)
     implementation(platform("com.google.firebase:firebase-bom:32.3.1"))
     implementation("com.google.firebase:firebase-messaging-ktx")
+
+    // Google Mobile Ads
+    implementation("com.google.android.gms:play-services-ads:22.6.0")
 
     // DataStore
     implementation("androidx.datastore:datastore-preferences:1.0.0")

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/dataAccess/MiuraboxService.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/dataAccess/MiuraboxService.kt
@@ -6,11 +6,11 @@ import com.cursosant.insurance.common.entities.Insurance
 import com.cursosant.insurance.common.entities.NotificationResponse
 import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.entities.PolicyDetail
-import com.cursosant.insurance.common.entities.PoliciesPage
 import com.cursosant.insurance.common.entities.SinisterResponse
 import com.cursosant.insurance.common.entities.AncoraDocsResponse
 import com.cursosant.insurance.common.entities.BaseResponse
 import com.cursosant.insurance.common.utils.Constants
+import com.cursosant.insurance.policiesModule.model.PolicyPagedResponse
 import retrofit2.http.FieldMap
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
@@ -24,8 +24,9 @@ interface MiuraboxService {
     @GET(Constants.PATH_POLICIES)
     suspend fun getPoliciesPageByUser(
         @Header(Constants.H_AUTHORIZATION) token: String,
-        @Query("page") page: Int? = null
-    ) : PoliciesPage
+        @Query("page") page: Int? = null,
+        @Query("page_size") pageSize: Int? = null
+    ) : PolicyPagedResponse
 
     @GET(Constants.PATH_POLICIES + "{${Constants.P_USERNAME}}")
     suspend fun getPoliciesInUser(

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
@@ -77,6 +77,7 @@ object Constants {
     const val V_URL_NAME = "grupoasapi"
     const val P_ORGANIZATION = "org"
     const val V_ORGANIZATION = "pruebas"
+    const val P_PAGE = "page"
     //Contact
     const val P_CONTACT_NAME = "from_name"
     const val P_CONTACT_EMAIL = "from_email"

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
@@ -1,8 +1,6 @@
 package com.cursosant.insurance.policiesModule.model
 
 import com.cursosant.insurance.common.dataAccess.MiuraboxService
-import com.cursosant.insurance.common.entities.PoliciesPage
-import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.utils.Constants
 import javax.inject.Inject
 
@@ -22,11 +20,11 @@ import javax.inject.Inject
  ***/
 class DataSource @Inject constructor(private val service: MiuraboxService) {
 
-    suspend fun getPolicies(token: String): List<Policy> {
-        return getPoliciesPage(token, null).policies
-    }
-
-    suspend fun getPoliciesPage(token: String, page: Int?): PoliciesPage {
-        return service.getPoliciesPageByUser("${Constants.H_BEARER}$token", page)
+    suspend fun getPolicies(
+        token: String,
+        page: Int?,
+        pageSize: Int?
+    ): PolicyPagedResponse {
+        return service.getPoliciesPageByUser("${Constants.H_BEARER}$token", page, pageSize)
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPagingSource.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPagingSource.kt
@@ -24,8 +24,9 @@ class PoliciesPagingSource(
         return try {
             val response = dataSource.getPolicies(token, page, pageSize)
             val policies = response.results.orEmpty()
+            val reportedPageSize = response.pageSize?.takeIf { it > 0 } ?: pageSize
 
-            val nextKey = resolveNextKey(response, page, policies.size)
+            val nextKey = resolveNextKey(response, page, policies.size, reportedPageSize)
             val prevKey = resolvePreviousKey(response, page)
 
             LoadResult.Page(
@@ -41,12 +42,13 @@ class PoliciesPagingSource(
     private fun resolveNextKey(
         response: PolicyPagedResponse,
         currentPage: Int,
-        currentSize: Int
+        currentSize: Int,
+        effectivePageSize: Int
     ): Int? {
         parsePageFromLink(response.next)?.let { return it }
 
         response.count?.let { total ->
-            val totalPages = if (pageSize == 0) 0 else (total + pageSize - 1) / pageSize
+            val totalPages = if (effectivePageSize <= 0) 0 else (total + effectivePageSize - 1) / effectivePageSize
             if (totalPages != 0 && currentPage >= totalPages) {
                 return null
             }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
@@ -1,7 +1,6 @@
 package com.cursosant.insurance.policiesModule.model
 
 import com.cursosant.insurance.common.entities.InsuranceException
-import com.cursosant.insurance.common.entities.PoliciesPage
 import com.cursosant.insurance.common.model.BaseRepository
 import com.cursosant.insurance.common.utils.TypeError
 import kotlinx.coroutines.Dispatchers
@@ -23,10 +22,10 @@ import javax.inject.Inject
  * www.alainnicolastello.com
  ***/
 class PoliciesRepository @Inject constructor(private val dataSource: DataSource) : BaseRepository() {
-    suspend fun getPolicies(token: String, page: Int?): PoliciesPage =
+    suspend fun getPolicies(token: String, page: Int?, pageSize: Int? = null): PolicyPagedResponse =
         withContext(Dispatchers.IO) {
-            executeAction<PoliciesPage>(InsuranceException(TypeError.POLICIES)) {
-                dataSource.getPoliciesPage(token, page)
+            executeAction<PolicyPagedResponse>(InsuranceException(TypeError.POLICIES)) {
+                dataSource.getPolicies(token, page, pageSize)
             }
         }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PolicyPagedResponse.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PolicyPagedResponse.kt
@@ -10,5 +10,7 @@ data class PolicyPagedResponse(
     @SerializedName("count") val count: Int? = null,
     @SerializedName("next") val next: String? = null,
     @SerializedName("previous") val previous: String? = null,
-    @SerializedName("results") val results: List<Policy>? = emptyList()
+    @SerializedName(value = "results", alternate = ["policies", "polizas"])
+    val results: List<Policy>? = emptyList(),
+    @SerializedName("page_size") val pageSize: Int? = null
 )

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
@@ -1,6 +1,7 @@
 package com.cursosant.insurance.policiesModule.view
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.cursosant.insurance.BR
+import com.cursosant.insurance.R
 import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.entities.User
 import com.cursosant.insurance.common.utils.Constants
@@ -17,6 +19,9 @@ import com.cursosant.insurance.databinding.FragmentPoliciesBinding
 import com.cursosant.insurance.policiesModule.view.adapters.OnClickListener
 import com.cursosant.insurance.policiesModule.view.adapters.PolicyAdapter
 import com.cursosant.insurance.policiesModule.viewModel.PoliciesViewModel
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.MobileAds
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -44,7 +49,23 @@ class PoliciesFragment : Fragment(), OnClickListener{
         setupViewModel()
         setupRecyclerView()
         setupButtons()
+        setupAdsIfPresent()
         setupObservers()
+    }
+
+    private fun setupAdsIfPresent() {
+        runCatching {
+            val adViewId = R.id.adView
+            val adView = binding.root.findViewById<AdView?>(adViewId)
+            if (adView != null) {
+                MobileAds.initialize(requireContext())
+                val adRequest = AdRequest.Builder().build()
+                adView.loadAd(adRequest)
+            }
+        }.onFailure { error ->
+            binding.root.findViewById<View?>(R.id.adView)?.visibility = View.GONE
+            Log.w(TAG, "Unable to initialize ads for policies screen", error)
+        }
     }
 
     private fun setupViewModel() {
@@ -106,5 +127,9 @@ class PoliciesFragment : Fragment(), OnClickListener{
             args.putString(Constants.ARG_POLICY_SUBRAMO, policy.subramo)
             navController.navigate(actionPoliciesToPolicyDetail, args)
         }
+    }
+
+    private companion object {
+        private const val TAG = "PoliciesFragment"
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
@@ -4,10 +4,11 @@ import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.cursosant.insurance.common.entities.InsuranceException
-import com.cursosant.insurance.common.entities.PoliciesPage
 import com.cursosant.insurance.common.entities.Policy
+import com.cursosant.insurance.common.utils.TypeError
 import com.cursosant.insurance.common.viewModel.BaseViewModel
 import com.cursosant.insurance.policiesModule.model.PoliciesRepository
+import com.cursosant.insurance.policiesModule.model.PolicyPagedResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -74,12 +75,16 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
         executeAction {
             try {
                 val result = repository.getPolicies(token, page)
-                updatePolicies(result.policies)
+                updatePolicies(result.results.orEmpty())
                 updatePaginationState(result, page)
             } catch (exception: InsuranceException) {
                 _canGoNext.postValue(previousNextState ?: false)
                 _canGoPrevious.postValue(previousPreviousState ?: false)
                 throw exception
+            } catch (throwable: Exception) {
+                _canGoNext.postValue(previousNextState ?: false)
+                _canGoPrevious.postValue(previousPreviousState ?: false)
+                throw InsuranceException(TypeError.POLICIES)
             }
         }
     }
@@ -100,11 +105,13 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
         _policies.postValue(policies)
     }
 
-    private fun updatePaginationState(page: PoliciesPage, requestedPage: Int) {
+    private fun updatePaginationState(page: PolicyPagedResponse, requestedPage: Int) {
         currentPage = requestedPage
         totalCount = page.count
-        if (pageSize == null && page.policies.isNotEmpty()) {
-            pageSize = page.policies.size
+        val results = page.results.orEmpty()
+        page.pageSize?.takeIf { it > 0 }?.let { pageSize = it }
+        if (pageSize == null && results.isNotEmpty()) {
+            pageSize = results.size
         }
 
         nextPage = extractPageNumber(page.next)
@@ -113,7 +120,7 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
         _canGoNext.postValue(nextPage != null)
         _canGoPrevious.postValue(previousPage != null)
 
-        val hasPolicies = page.policies.isNotEmpty()
+        val hasPolicies = results.isNotEmpty()
         val hasCount = hasTotalCount()
         val hasNavigation = nextPage != null || previousPage != null
         val shouldShowIndicator = hasPolicies || hasCount || hasNavigation

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/ids.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="adView" type="id" />
+</resources>


### PR DESCRIPTION
## Summary
- add the Google Mobile Ads dependency to the Insurance library so the policies screen can inflate its ad banner without crashing
- lazily initialize the optional ad view in `PoliciesFragment` and hide it when Google Play services are unavailable
- publish a shared `@id/adView` so host layouts can reference the banner without redefining the identifier

## Testing
- ./gradlew :XIvan:Library:Insurance:compileDebugKotlin *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68efdc9023bc832a9c83f63287840d1d