### PR TITLE
Add pagination footer to policies list

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
@@ -21,6 +21,7 @@ import com.cursosant.insurance.common.utils.UiUtils
 import com.cursosant.insurance.databinding.FragmentPoliciesBinding
 import com.cursosant.insurance.policiesModule.view.adapters.OnClickListener
 import com.cursosant.insurance.policiesModule.view.adapters.PolicyAdapter
+import com.cursosant.insurance.policiesModule.view.adapters.PoliciesLoadStateAdapter
 import com.cursosant.insurance.policiesModule.viewModel.PoliciesViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -62,10 +63,14 @@ class PoliciesFragment : Fragment(), OnClickListener{
     }
 
     private fun setupRecyclerView() {
+        val adapterWithFooter = adapter.withLoadStateFooter(
+            PoliciesLoadStateAdapter { adapter.retry() }
+        )
+
         binding.recyclerView.apply {
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireActivity())
-            adapter = this@PoliciesFragment.adapter
+            adapter = adapterWithFooter
         }.also { adapter.setOnClickListener(this) }
     }
 

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/adapters/PoliciesLoadStateAdapter.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/adapters/PoliciesLoadStateAdapter.kt
@@ -1,0 +1,50 @@
+package com.cursosant.insurance.policiesModule.view.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.paging.LoadState
+import androidx.paging.LoadStateAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.cursosant.insurance.R
+import com.cursosant.insurance.databinding.ItemPoliciesLoadStateBinding
+
+class PoliciesLoadStateAdapter(
+    private val retry: () -> Unit
+) : LoadStateAdapter<PoliciesLoadStateAdapter.LoadStateViewHolder>() {
+
+    override fun onBindViewHolder(holder: LoadStateViewHolder, loadState: LoadState) {
+        holder.bind(loadState)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, loadState: LoadState): LoadStateViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        val binding = ItemPoliciesLoadStateBinding.inflate(layoutInflater, parent, false)
+        return LoadStateViewHolder(binding, retry)
+    }
+
+    class LoadStateViewHolder(
+        private val binding: ItemPoliciesLoadStateBinding,
+        retry: () -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.btnRetry.setOnClickListener { retry() }
+        }
+
+        fun bind(loadState: LoadState) {
+            val isLoading = loadState is LoadState.Loading
+            val isError = loadState is LoadState.Error
+
+            binding.progressBar.isVisible = isLoading
+            binding.btnRetry.isVisible = isError
+            binding.tvErrorMessage.isVisible = isError
+
+            if (isError) {
+                val errorMessage = loadState.error.localizedMessage
+                    ?: binding.root.context.getString(R.string.policies_error)
+                binding.tvErrorMessage.text = errorMessage
+            }
+        }
+    }
+}

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/item_policies_load_state.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/item_policies_load_state.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true" />
+
+        <TextView
+            android:id="@+id/tvErrorMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurface"
+            tools:text="No se pudieron cargar las pólizas" />
+
+        <Button
+            android:id="@+id/btnRetry"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/retry_btn_retry" />
+
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
## Summary
- add a dedicated paging LoadStateAdapter for the policies list
- show loading and error states in the policies RecyclerView footer to make pagination visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68effcab0448832ab764a4206f1c29fb