### PR TITLE
Enhance policies paging load state visuals

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
@@ -21,6 +21,7 @@ import com.cursosant.insurance.common.utils.UiUtils
 import com.cursosant.insurance.databinding.FragmentPoliciesBinding
 import com.cursosant.insurance.policiesModule.view.adapters.OnClickListener
 import com.cursosant.insurance.policiesModule.view.adapters.PolicyAdapter
+import com.cursosant.insurance.policiesModule.view.adapters.PoliciesLoadStateAdapter
 import com.cursosant.insurance.policiesModule.viewModel.PoliciesViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -62,11 +63,16 @@ class PoliciesFragment : Fragment(), OnClickListener{
     }
 
     private fun setupRecyclerView() {
+        val adapterWithLoadState = adapter.withLoadStateHeaderAndFooter(
+            header = PoliciesLoadStateAdapter { adapter.retry() },
+            footer = PoliciesLoadStateAdapter { adapter.retry() }
+        )
+
         binding.recyclerView.apply {
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireActivity())
-            adapter = this@PoliciesFragment.adapter
-        }.also { adapter.setOnClickListener(this) }
+            adapter = adapterWithLoadState
+        }.also { adapter.setOnClickListener(this@PoliciesFragment) }
     }
 
     private fun setupObservers() {

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/adapters/PoliciesLoadStateAdapter.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/adapters/PoliciesLoadStateAdapter.kt
@@ -1,0 +1,53 @@
+package com.cursosant.insurance.policiesModule.view.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.paging.LoadState
+import androidx.paging.LoadStateAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.cursosant.insurance.R
+import com.cursosant.insurance.databinding.ItemPoliciesLoadStateBinding
+
+class PoliciesLoadStateAdapter(
+    private val retry: () -> Unit
+) : LoadStateAdapter<PoliciesLoadStateAdapter.LoadStateViewHolder>() {
+
+    override fun onBindViewHolder(holder: LoadStateViewHolder, loadState: LoadState) {
+        holder.bind(loadState)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, loadState: LoadState): LoadStateViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        val binding = ItemPoliciesLoadStateBinding.inflate(layoutInflater, parent, false)
+        return LoadStateViewHolder(binding, retry)
+    }
+
+    class LoadStateViewHolder(
+        private val binding: ItemPoliciesLoadStateBinding,
+        retry: () -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.btnRetry.setOnClickListener { retry() }
+        }
+
+        fun bind(loadState: LoadState) {
+            val isLoading = loadState is LoadState.Loading
+            val isError = loadState is LoadState.Error
+
+            binding.progressIndicator.isVisible = isLoading
+            binding.tvLoadingMessage.isVisible = isLoading
+
+            binding.btnRetry.isVisible = isError
+            binding.tvErrorMessage.isVisible = isError
+
+            if (isError) {
+                val errorState = loadState as? LoadState.Error
+                val errorMessage = errorState?.error?.localizedMessage
+                    ?: binding.root.context.getString(R.string.policies_error)
+                binding.tvErrorMessage.text = errorMessage
+            }
+        }
+    }
+}

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/item_policies_load_state.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/item_policies_load_state.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="20dp">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progressIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:indicatorSize="40dp"
+            app:trackThickness="4dp"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/tvLoadingMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/policies_loading_more"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurface"
+            android:visibility="gone"
+            tools:text="Cargando más pólizas…"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/tvErrorMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorError"
+            android:visibility="gone"
+            tools:text="No se pudieron cargar las pólizas" />
+
+        <Button
+            android:id="@+id/btnRetry"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/retry_btn_retry"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </LinearLayout>
+</layout>

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/strings.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/strings.xml
@@ -193,6 +193,7 @@
     <string name="insurers_error">No se encontraron aseguradoras.</string>
 
     <string name="policies_error">No se encontraron pólizas</string>
+    <string name="policies_loading_more">Cargando más pólizas…</string>
 
     <string name="policy_detail_btn_share">Compartir</string>
     <string name="policy_detail_btn_edit">Editar</string>


### PR DESCRIPTION
## Summary
- attach paging header and footer adapters so load state UI is displayed consistently while scrolling
- update the load state layout to surface a circular progress indicator and retry action messaging
- add a localized message for the footer loading indicator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68effcab0448832ab764a4206f1c29fb