### PR TITLE
Support paged policy retrieval

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     val hiltVersion = "2.47"
     val navigationVersion = "2.6.0"
     val lifecycleVersion = "2.6.2"
+    val pagingVersion = "3.2.1"
 
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.9.24"))
     implementation("androidx.core:core-ktx:$coreKtxVersion")
@@ -83,6 +84,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
+
+    // Paging
+    implementation("androidx.paging:paging-runtime-ktx:$pagingVersion")
 
     // Retrofit + OkHttp
     implementation("com.squareup.retrofit2:retrofit:2.9.0")

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/dataAccess/MiuraboxService.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/dataAccess/MiuraboxService.kt
@@ -10,6 +10,7 @@ import com.cursosant.insurance.common.entities.PoliciesPage
 import com.cursosant.insurance.common.entities.SinisterResponse
 import com.cursosant.insurance.common.entities.AncoraDocsResponse
 import com.cursosant.insurance.common.entities.BaseResponse
+import com.cursosant.insurance.policiesModule.model.PolicyPagedResponse
 import com.cursosant.insurance.common.utils.Constants
 import retrofit2.http.FieldMap
 import retrofit2.http.FormUrlEncoded
@@ -26,6 +27,14 @@ interface MiuraboxService {
         @Header(Constants.H_AUTHORIZATION) token: String,
         @Query("page") page: Int? = null
     ) : PoliciesPage
+
+    @GET(Constants.PATH_POLICIES)
+    suspend fun getPoliciesPaged(
+        @Header(Constants.H_AUTHORIZATION) token: String,
+        @Query(Constants.P_USERNAME) username: String,
+        @Query(Constants.P_PAGE) page: Int? = null,
+        @Query(Constants.P_PAGE_SIZE) pageSize: Int? = null
+    ): PolicyPagedResponse
 
     @GET(Constants.PATH_POLICIES + "{${Constants.P_USERNAME}}")
     suspend fun getPoliciesInUser(

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/entities/PoliciesPage.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/entities/PoliciesPage.kt
@@ -1,0 +1,14 @@
+package com.cursosant.insurance.common.entities
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Representa una página de resultados de pólizas usando el esquema legado del módulo.
+ */
+data class PoliciesPage(
+    @SerializedName("count") val count: Int? = null,
+    @SerializedName("next") val next: String? = null,
+    @SerializedName("previous") val previous: String? = null,
+    @SerializedName(value = "policies", alternate = ["results"])
+    val policies: List<Policy> = emptyList()
+)

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
@@ -77,6 +77,8 @@ object Constants {
     const val V_URL_NAME = "grupoasapi"
     const val P_ORGANIZATION = "org"
     const val V_ORGANIZATION = "pruebas"
+    const val P_PAGE = "page"
+    const val P_PAGE_SIZE = "page_size"
     //Contact
     const val P_CONTACT_NAME = "from_name"
     const val P_CONTACT_EMAIL = "from_email"

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/DataSource.kt
@@ -29,4 +29,19 @@ class DataSource @Inject constructor(private val service: MiuraboxService) {
     suspend fun getPoliciesPage(token: String, page: Int?): PoliciesPage {
         return service.getPoliciesPageByUser("${Constants.H_BEARER}$token", page)
     }
+
+    suspend fun getPolicies(
+        token: String,
+        username: String,
+        page: Int?,
+        pageSize: Int
+    ): PolicyPagedResponse {
+        val normalizedPageSize = pageSize.takeIf { it > 0 }
+        return service.getPoliciesPaged(
+            "${Constants.H_BEARER}$token",
+            username,
+            page,
+            normalizedPageSize
+        )
+    }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/item_policies_load_state.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/item_policies_load_state.xml
@@ -29,7 +29,7 @@
             android:layout_marginTop="12dp"
             android:text="@string/policies_loading_more"
             android:textAppearance="?attr/textAppearanceBodyMedium"
-            android:textColor="?attr/colorOnSurface"
+            android:textColor="@color/color_on_surface"
             android:visibility="gone"
             tools:text="Cargando más pólizas…"
             tools:visibility="visible" />
@@ -40,7 +40,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:textAppearance="?attr/textAppearanceBodyMedium"
-            android:textColor="?attr/colorError"
+            android:textColor="@color/color_error"
             android:visibility="gone"
             tools:text="No se pudieron cargar las pólizas" />
 

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/res/values/strings.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/app/src/main/res/values/strings.xml
@@ -22,6 +22,14 @@
         \n\nEn cualquier momento Ega México Agente de Seguros y Fianzas, Sociedad Anónima de Capital Variable puede hacer modificaciones o actualizaciones al presente Aviso de Privacidad para la atención de novedades legislativas, políticas internas o nuevos requerimientos para la administración de quejas y reclamaciones de los clientes.\n
 </string>
 
+    <string name="policies">Pólizas</string>
+    <string name="policies_loading_more">Cargando mis pólizas…</string>
+    <string name="policies_error">No se pudieron cargar las pólizas</string>
+    <string name="policies_progress_msg">Consultando pólizas…</string>
+    <string name="policies_empty_msg">No hay pólizas registradas</string>
+    <string name="policies_previous">Anterior</string>
+    <string name="policies_next">Siguiente</string>
+
     <string name="about_description">Broker dedicado a la correduría de seguros y fianzas con vasta experiencia desarrollando programas para mercados empresariales y corporativos desde 1991.
         \n\nNuestro activo más valioso son nuestros clientes satisfechos. Mantenemos una alianza comercial con los grupos aseguradores más importantes de México. Diplomados en Seguros por el IMESFAC y con acreditaciones para operación en todos los ramos. Brindamos servicio a un selecto mercado de clientes de diversas partes de la República y Estados Unidos. Ofrecemos programas de seguros y fianzas específicos y a la medida. Nuestros socios comerciales en conjunto brindan más del 90% de la cobertura del mercado asegurador mexicano. Contamos con más de 20,000 aseguramientos con un equipo profesional y calificado así como más de 20 agentes asociados. Nuestros colaboradores cuentan con cursos de especialización en diversos foros así como en la EGADE del Tec de Monterrey.</string>
 


### PR DESCRIPTION
## Summary
- add the AndroidX Paging runtime dependency to the Insurance library module so PagingSource resolves
- expose the username-aware paginated policies endpoint through the Retrofit service and data source helpers so the paging source can load data
- add a PoliciesPage entity that maps both legacy `policies` and new `results` payload keys for compatibility

## Testing
- ./gradlew -p app tasks *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68f00ff85e08832a9dab2d0552e3e406