### PR TITLE
Fix LoginViewModel instantiation

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/loginModule/view/LoginFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/loginModule/view/LoginFragment.kt
@@ -19,6 +19,7 @@ import com.cursosant.insurance.common.utils.NavUtils
 import com.cursosant.insurance.common.utils.UiUtils
 import com.cursosant.insurance.common.utils.Utils
 import com.cursosant.insurance.databinding.FragmentLoginBinding
+import com.cursosant.insurance.loginModule.model.LoginRepository
 import com.cursosant.insurance.loginModule.viewModel.LoginDialogConfig
 import com.cursosant.insurance.loginModule.viewModel.LoginViewModel
 import com.cursosant.insurance.mainModule.viewModel.MainViewModel
@@ -49,6 +50,7 @@ open class LoginFragment : Fragment() {
     @Inject lateinit var uiUtils: UiUtils
     @Inject lateinit var utils: Utils
     @Inject lateinit var navUtils: NavUtils
+    @Inject lateinit var loginRepository: LoginRepository
 
     private var gson: Gson? = null
     var gsonBuilder = GsonBuilder()
@@ -57,7 +59,9 @@ open class LoginFragment : Fragment() {
     private var _binding: FragmentLoginBinding? = null
     private val binding get() = _binding!!
     private var messageDialog: AlertDialog? = null
-    private val viewModel: LoginViewModel by viewModels()
+    private val viewModel: LoginViewModel by viewModels {
+        LoginViewModel.provideFactory(loginRepository)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentLoginBinding.inflate(inflater, container, false)

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/loginModule/viewModel/LoginViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/loginModule/viewModel/LoginViewModel.kt
@@ -3,14 +3,14 @@ package com.cursosant.insurance.loginModule.viewModel
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.liveData
 import com.cursosant.insurance.R
 import com.cursosant.insurance.common.viewModel.BaseViewModel
 import com.cursosant.insurance.loginModule.model.LoginRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
-@HiltViewModel
 class LoginViewModel @Inject constructor(
     private val repository: LoginRepository
 ) : BaseViewModel() {
@@ -98,6 +98,20 @@ class LoginViewModel @Inject constructor(
 
     fun onDialogConsumed() {
         _dialogConfig.value = null
+    }
+
+    companion object {
+        fun provideFactory(
+            repository: LoginRepository
+        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
+                    @Suppress("UNCHECKED_CAST")
+                    return LoginViewModel(repository) as T
+                }
+                throw IllegalArgumentException("Unknown ViewModel class: ${'$'}modelClass")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- inject the login repository into the login fragment so it can supply a custom ViewModel factory
- add a companion factory helper inside LoginViewModel to create instances with the injected repository

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f03b961fc4832aa0bd5444baba5559