### PR TITLE
Refactor policies pagination flow

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPagingSource.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPagingSource.kt
@@ -1,79 +1,36 @@
 package com.cursosant.insurance.policiesModule.model
 
-import android.net.Uri
-import androidx.paging.PagingSource
-import androidx.paging.PagingState
-import com.cursosant.insurance.common.entities.Policy
-import com.cursosant.insurance.common.utils.Constants
-import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
 
-class PoliciesPagingSource(
-    private val dataSource: DataSource,
-    private val token: String,
-    private val username: String,
-    private val pageSize: Int
-) : PagingSource<Int, Policy>() {
+/**
+ * Encapsula la lógica de consulta paginada de pólizas.
+ *
+ * Aunque el módulo ya no usa directamente la librería de Paging3, se mantiene esta clase
+ * para centralizar la forma en que se normaliza la página solicitada y se delega al
+ * [DataSource] real. De esta manera el repositorio puede seguir solicitando páginas
+ * específicas (inicial o subsecuentes) tal como lo hace SegumovilApp.
+ */
+class PoliciesPagingSource @Inject constructor(private val dataSource: DataSource) {
 
-    override fun getRefreshKey(state: PagingState<Int, Policy>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            val anchorPage = state.closestPageToPosition(anchorPosition)
-            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
-        }
-    }
+    suspend fun load(
+        token: String,
+        username: String,
+        page: Int?,
+        pageSize: Int
+    ): PolicyPagedResponse {
+        val normalizedPage = page?.takeIf { it > 0 } ?: FIRST_PAGE
+        val normalizedPageSize = if (pageSize > 0) pageSize else DEFAULT_PAGE_SIZE
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Policy> {
-        val page = params.key ?: FIRST_PAGE
-        val loadSize = params.loadSize.takeIf { it > 0 } ?: pageSize
-        return try {
-            val response = dataSource.getPolicies(token, username, page, loadSize)
-            val policies = response.items
-
-            val nextKey = resolveNextKey(response, page, policies.size, loadSize)
-            val prevKey = resolvePreviousKey(response, page)
-
-            LoadResult.Page(
-                data = policies,
-                prevKey = prevKey,
-                nextKey = nextKey
-            )
-        } catch (exception: Exception) {
-            if (exception is CancellationException) throw exception
-            LoadResult.Error(exception)
-        }
-    }
-
-    private fun resolveNextKey(
-        response: PolicyPagedResponse,
-        currentPage: Int,
-        currentSize: Int,
-        loadSize: Int
-    ): Int? {
-        parsePageFromLink(response.next)?.let { return it }
-
-        response.totalCount.let { total ->
-            val effectivePageSize = if (loadSize > 0) loadSize else pageSize
-            val totalPages = if (effectivePageSize == 0) 0 else (total + effectivePageSize - 1) / effectivePageSize
-            if (totalPages != 0 && currentPage >= totalPages) {
-                return null
-            }
-        }
-
-        return if (currentSize == 0) null else currentPage + 1
-    }
-
-    private fun resolvePreviousKey(response: PolicyPagedResponse, currentPage: Int): Int? {
-        parsePageFromLink(response.previous)?.let { return it }
-        return if (currentPage == FIRST_PAGE) null else currentPage - 1
-    }
-
-    private fun parsePageFromLink(link: String?): Int? {
-        if (link.isNullOrBlank()) return null
-        return runCatching {
-            Uri.parse(link).getQueryParameter(Constants.P_PAGE)?.toInt()
-        }.getOrNull()
+        return dataSource.getPolicies(
+            token = token,
+            username = username,
+            page = normalizedPage,
+            pageSize = normalizedPageSize
+        )
     }
 
     companion object {
-        private const val FIRST_PAGE = 1
+        const val FIRST_PAGE = 1
+        private const val DEFAULT_PAGE_SIZE = 20
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
@@ -1,12 +1,11 @@
 package com.cursosant.insurance.policiesModule.model
 
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import com.cursosant.insurance.common.entities.Policy
+import com.cursosant.insurance.common.entities.InsuranceException
 import com.cursosant.insurance.common.model.BaseRepository
-import kotlinx.coroutines.flow.Flow
+import com.cursosant.insurance.common.utils.TypeError
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /****
  * Project: Insurance
@@ -22,25 +21,34 @@ import javax.inject.Inject
  * Coupons on my Website:
  * www.alainnicolastello.com
  ***/
-class PoliciesRepository @Inject constructor(private val dataSource: DataSource) : BaseRepository() {
-    fun getPolicies(token: String, username: String): Flow<PagingData<Policy>> {
+class PoliciesRepository @Inject constructor(
+    private val pagingSource: PoliciesPagingSource
+) : BaseRepository() {
+
+    suspend fun getPoliciesPage(
+        token: String,
+        username: String,
+        page: Int
+    ): PolicyPagedResponse {
         val normalizedToken = token.trim()
         val normalizedUsername = username.trim()
 
-        return Pager(
-            config = PagingConfig(
-                pageSize = PAGE_SIZE,
-                enablePlaceholders = false
-            ),
-            pagingSourceFactory = {
-                PoliciesPagingSource(
-                    dataSource = dataSource,
+        if (normalizedToken.isEmpty() || normalizedUsername.isEmpty()) {
+            return PolicyPagedResponse.EMPTY
+        }
+
+        val exception = InsuranceException(TypeError.POLICIES)
+
+        return withContext(Dispatchers.IO) {
+            executeAction(exception) {
+                pagingSource.load(
                     token = normalizedToken,
                     username = normalizedUsername,
+                    page = page,
                     pageSize = PAGE_SIZE
                 )
             }
-        ).flow
+        }
     }
 
     companion object {

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
@@ -6,10 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
-import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.cursosant.insurance.R
 import com.cursosant.insurance.common.entities.Policy
@@ -20,11 +16,8 @@ import com.cursosant.insurance.common.utils.UiUtils
 import com.cursosant.insurance.databinding.FragmentPoliciesBinding
 import com.cursosant.insurance.policiesModule.view.adapters.OnClickListener
 import com.cursosant.insurance.policiesModule.view.adapters.PolicyAdapter
-import com.cursosant.insurance.policiesModule.view.adapters.PoliciesLoadStateAdapter
 import com.cursosant.insurance.policiesModule.viewModel.PoliciesViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -63,14 +56,10 @@ class PoliciesFragment : Fragment(), OnClickListener {
     }
 
     private fun setupRecyclerView() {
-        val adapterWithFooter = adapter.withLoadStateFooter(
-            PoliciesLoadStateAdapter { adapter.retry() }
-        )
-
         binding.recyclerView.apply {
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireActivity())
-            adapter = adapterWithFooter
+            adapter = this@PoliciesFragment.adapter
         }.also { adapter.setOnClickListener(this) }
     }
 
@@ -81,41 +70,15 @@ class PoliciesFragment : Fragment(), OnClickListener {
         viewModel.policies.observe(viewLifecycleOwner) { result ->
             adapter.submitData(viewLifecycleOwner.lifecycle, result)
         }
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                adapter.loadStateFlow.collectLatest { loadState ->
-                    val refreshState = loadState.refresh
-                    viewModel.updateLoading(refreshState is LoadState.Loading)
-
-                    if (refreshState is LoadState.Loading) {
-                        viewModel.setPoliciesEmpty(false)
-                    }
-
-                    val errorState = refreshState as? LoadState.Error
-                        ?: loadState.append as? LoadState.Error
-                        ?: loadState.prepend as? LoadState.Error
-
-                    if (errorState != null) {
-                        if (adapter.itemCount == 0) {
-                            viewModel.setPoliciesEmpty(true)
-                            binding.retryContainer.msg = getString(R.string.policies_error)
-                        }
-                        viewModel.notifyPoliciesError()
-                    } else {
-                        val isListEmpty = refreshState is LoadState.NotLoading && adapter.itemCount == 0
-                        viewModel.setPoliciesEmpty(isListEmpty)
-                        if (isListEmpty) {
-                            binding.retryContainer.msg = getString(R.string.policies_empty_msg)
-                        }
-                    }
-                }
-            }
+        viewModel.emptyStateMessage.observe(viewLifecycleOwner) { resId ->
+            binding.retryContainer.msg = getString(resId)
         }
     }
 
     private fun setupButtons() {
-        binding.retryContainer.btnRetry.setOnClickListener { adapter.retry() }
+        binding.retryContainer.btnRetry.setOnClickListener {
+            viewModel.refreshCurrentPage()
+        }
     }
 
     override fun onResume() {
@@ -124,9 +87,9 @@ class PoliciesFragment : Fragment(), OnClickListener {
     }
 
     private fun getPolicies() {
-        User.instance?.let { user ->
-            viewModel.getPolicies(user.token.token, user.username)
-        }
+        val user = User.instance
+        viewModel.onSessionAvailable(user?.token?.token, user?.username)
+        viewModel.refreshCurrentPage()
     }
 
     override fun onDestroyView() {

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
@@ -4,15 +4,18 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
-import androidx.paging.cachedIn
+import androidx.paging.PagingData.Companion.empty
+import androidx.paging.PagingData.Companion.from
 import com.cursosant.insurance.R
+import com.cursosant.insurance.common.entities.InsuranceException
 import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.viewModel.BaseViewModel
+import com.cursosant.insurance.policiesModule.model.PoliciesPagingSource
 import com.cursosant.insurance.policiesModule.model.PoliciesRepository
+import com.cursosant.insurance.policiesModule.model.PolicyPagedResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /****
@@ -30,36 +33,80 @@ import kotlinx.coroutines.launch
  * www.alainnicolastello.com
  ***/
 @HiltViewModel
-class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepository) : BaseViewModel() {
-    private val _policies = MutableLiveData<PagingData<Policy>>()
+class PoliciesViewModel @Inject constructor(
+    private val repository: PoliciesRepository
+) : BaseViewModel() {
+
+    private val _policies = MutableLiveData<PagingData<Policy>>(empty())
     val policies: LiveData<PagingData<Policy>> = _policies
 
     private val _isPoliciesEmpty = MutableLiveData(false)
     val isPoliciesEmpty: LiveData<Boolean> = _isPoliciesEmpty
 
-    private var fetchJob: Job? = null
+    private val _isNextEnabled = MutableLiveData(false)
+    val isNextEnabled: LiveData<Boolean> = _isNextEnabled
 
-    fun getPolicies(token: String?, username: String?) {
+    private val _isPreviousEnabled = MutableLiveData(false)
+    val isPreviousEnabled: LiveData<Boolean> = _isPreviousEnabled
+
+    private val _pageIndicator = MutableLiveData<String>()
+    val pageIndicator: LiveData<String> = _pageIndicator
+
+    private val _emptyStateMessage = MutableLiveData(R.string.policies_empty_msg)
+    val emptyStateMessage: LiveData<Int> = _emptyStateMessage
+
+    private var sessionToken: String = ""
+    private var sessionUsername: String = ""
+    private var currentPage: Int = PoliciesPagingSource.FIRST_PAGE
+    private var totalPages: Int = 0
+    private var hasLoadedAnyPage = false
+    private var isLoadingPage = false
+    private var loadJob: Job? = null
+
+    fun onSessionAvailable(token: String?, username: String?) {
         val normalizedToken = token?.trim().orEmpty()
         val normalizedUsername = username?.trim().orEmpty()
 
         if (normalizedToken.isEmpty() || normalizedUsername.isEmpty()) {
-            _policies.postValue(PagingData.empty())
-            setPoliciesEmpty(true)
-            updateLoading(false)
+            clearPolicies()
             return
         }
 
-        fetchJob?.cancel()
-        _isPoliciesEmpty.postValue(false)
-        fetchJob = viewModelScope.launch {
-            repository.getPolicies(normalizedToken, normalizedUsername)
-                .cachedIn(viewModelScope)
-                .collectLatest { pagingData ->
-                    _policies.postValue(pagingData)
-                }
+        val hasSessionChanged =
+            normalizedToken != sessionToken || normalizedUsername != sessionUsername
+
+        sessionToken = normalizedToken
+        sessionUsername = normalizedUsername
+
+        if (hasSessionChanged) {
+            resetPagination()
         }
     }
+
+    fun refreshCurrentPage() {
+        if (sessionToken.isEmpty() || sessionUsername.isEmpty()) {
+            clearPolicies()
+            return
+        }
+
+        loadPage(currentPage)
+    }
+
+    fun loadNextPage() {
+        if (_isNextEnabled.value != true) return
+        val targetPage = if (totalPages == 0) currentPage + 1 else minOf(currentPage + 1, totalPages)
+        loadPage(targetPage)
+    }
+
+    fun loadPreviousPage() {
+        if (_isPreviousEnabled.value != true) return
+        val targetPage = maxOf(currentPage - 1, PoliciesPagingSource.FIRST_PAGE)
+        loadPage(targetPage)
+    }
+
+    fun onNextPageClicked() = loadNextPage()
+
+    fun onPreviousPageClicked() = loadPreviousPage()
 
     fun setPoliciesEmpty(isEmpty: Boolean) {
         _isPoliciesEmpty.postValue(isEmpty)
@@ -71,5 +118,121 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
 
     fun notifyPoliciesError() {
         showMsg(R.string.policies_error)
+    }
+
+    private fun loadPage(requestedPage: Int) {
+        if (isLoadingPage) return
+        val safePage = maxOf(requestedPage, PoliciesPagingSource.FIRST_PAGE)
+
+        isLoadingPage = true
+        updateLoading(true)
+        _isPoliciesEmpty.postValue(false)
+        _emptyStateMessage.postValue(R.string.policies_empty_msg)
+
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            try {
+                val response = repository.getPoliciesPage(
+                    token = sessionToken,
+                    username = sessionUsername,
+                    page = safePage
+                )
+
+                handlePoliciesResponse(response, safePage)
+            } catch (exception: InsuranceException) {
+                handlePoliciesError(exception)
+            } catch (exception: Exception) {
+                handlePoliciesError(null)
+            } finally {
+                isLoadingPage = false
+                updateLoading(false)
+            }
+        }
+    }
+
+    private fun handlePoliciesResponse(response: PolicyPagedResponse, page: Int) {
+        val policies = response.items
+        val pagingData = if (policies.isEmpty()) empty<Policy>() else from(policies)
+
+        _policies.postValue(pagingData)
+
+        val isEmpty = policies.isEmpty()
+        _isPoliciesEmpty.postValue(isEmpty)
+
+        val totalCount = response.totalCount
+        totalPages = calculateTotalPages(totalCount)
+        currentPage = minOf(page, if (totalPages == 0) page else totalPages)
+        hasLoadedAnyPage = true
+
+        updatePaginationControls(response, policies.size)
+    }
+
+    private fun calculateTotalPages(totalCount: Int): Int {
+        if (totalCount <= 0) return 0
+        return (totalCount + PAGE_SIZE - 1) / PAGE_SIZE
+    }
+
+    private fun updatePaginationControls(response: PolicyPagedResponse, currentSize: Int) {
+        val hasNext = hasNextPage(response, currentSize)
+        val hasPrevious = hasPreviousPage(response)
+
+        _isNextEnabled.postValue(hasNext)
+        _isPreviousEnabled.postValue(hasPrevious)
+
+        val indicator = buildPageIndicator()
+        _pageIndicator.postValue(indicator)
+    }
+
+    private fun hasNextPage(response: PolicyPagedResponse, currentSize: Int): Boolean {
+        if (!response.next.isNullOrBlank()) return true
+        if (totalPages == 0) return currentSize >= PAGE_SIZE
+        return currentPage < totalPages
+    }
+
+    private fun hasPreviousPage(response: PolicyPagedResponse): Boolean {
+        if (!response.previous.isNullOrBlank()) return true
+        return currentPage > PoliciesPagingSource.FIRST_PAGE
+    }
+
+    private fun buildPageIndicator(): String {
+        val safeTotalPages = if (totalPages == 0 && hasLoadedAnyPage) 1 else totalPages
+        val current = if (hasLoadedAnyPage) currentPage else PoliciesPagingSource.FIRST_PAGE
+        return "$current / ${if (safeTotalPages == 0) 1 else safeTotalPages}"
+    }
+
+    private fun handlePoliciesError(exception: InsuranceException?) {
+        exception?.let { showMsg(it.typeError.resMsg) } ?: showMsg(R.string.policies_error)
+        if (!hasLoadedAnyPage) {
+            _isPoliciesEmpty.postValue(true)
+            _emptyStateMessage.postValue(R.string.policies_error)
+        }
+        _isNextEnabled.postValue(false)
+        _isPreviousEnabled.postValue(currentPage > PoliciesPagingSource.FIRST_PAGE)
+    }
+
+    private fun resetPagination() {
+        loadJob?.cancel()
+        loadJob = null
+        isLoadingPage = false
+        currentPage = PoliciesPagingSource.FIRST_PAGE
+        totalPages = 0
+        hasLoadedAnyPage = false
+        _policies.postValue(empty())
+        _isPoliciesEmpty.postValue(false)
+        _isNextEnabled.postValue(false)
+        _isPreviousEnabled.postValue(false)
+        _pageIndicator.postValue(null)
+        _emptyStateMessage.postValue(R.string.policies_empty_msg)
+    }
+
+    private fun clearPolicies() {
+        sessionToken = ""
+        sessionUsername = ""
+        resetPagination()
+        updateLoading(false)
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 20
     }
 }


### PR DESCRIPTION
## Summary
- Replace the previous Paging3-based paging source with a wrapper that retrieves explicit pages through the existing data source.
- Update the repository to fetch pages on the IO dispatcher and centralize InsuranceException handling while keeping page size normalization.
- Rebuild the view model around the new pagination contract, exposing LiveData for next/previous controls, page indicators, and guarding simultaneous requests with reset logic.
- Simplify the fragment so it observes the updated state, delegates pagination actions to the view model, and reuses the retry control for refreshes.

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: proxy returned HTTP 403 while downloading Gradle 8.13)*

------
https://chatgpt.com/codex/tasks/task_e_68f0476e2594832ab0fe94b3e0ab9c9c