### PR TITLE
Add manual pagination controls for policies

### DIFF
--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/common/utils/Constants.kt
@@ -32,7 +32,7 @@ object Constants {
     const val PATH_DELETE_ACCOUNT = "/desactivar-usuario-app"
     const val PATH_DISABLE_ACCOUNT = "/desactivar_user_app"
 
-    const val PATH_POLICIES = "/poliza-by-user-app/"
+    const val PATH_POLICIES = "/poliza-by-user-app-paginado/"
     const val PATH_INSURERS = "/provider-by-user-app/"
     const val PATH_POLICY = "/v1/policies-detail-app/"
     const val PATH_DOCUMENTS = "/archivos/editables/"

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPageMetadata.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPageMetadata.kt
@@ -1,0 +1,13 @@
+package com.cursosant.insurance.policiesModule.model
+
+/**
+ * Información básica de paginación que permite a la capa de UI conocer
+ * el estado actual del listado (página, totales y navegación disponible).
+ */
+data class PoliciesPageMetadata(
+    val currentPage: Int,
+    val totalPages: Int,
+    val totalCount: Int,
+    val hasPrevious: Boolean,
+    val hasNext: Boolean
+)

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPagingSource.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesPagingSource.kt
@@ -5,13 +5,22 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.utils.Constants
+import java.io.IOException
+import kotlin.math.max
+import retrofit2.HttpException
 
 class PoliciesPagingSource(
     private val dataSource: DataSource,
     private val token: String,
-    private val pageSize: Int
+    private val pageSize: Int,
+    private val manualNavigation: Boolean = false,
+    private val onPageMetadata: (PoliciesPageMetadata) -> Unit = {}
 ) : PagingSource<Int, Policy>() {
 
+    /**
+     * Paging 3 utiliza esta clave para intentar volver a cargar datos cercanos al ítem
+     * que el usuario está visualizando después de una invalidación.
+     */
     override fun getRefreshKey(state: PagingState<Int, Policy>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             val anchorPage = state.closestPageToPosition(anchorPosition)
@@ -22,18 +31,31 @@ class PoliciesPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Policy> {
         val page = params.key ?: FIRST_PAGE
         return try {
+            // Realizamos la petición HTTP utilizando Retrofit a través del DataSource.
             val response = dataSource.getPolicies(token, page, pageSize)
+
+            // Extraemos la lista de pólizas desde el campo "results" de la respuesta paginada.
             val policies = response.results.orEmpty()
 
+            // Calculamos las claves de navegación basándonos en los enlaces "next" y "previous".
             val nextKey = resolveNextKey(response, page, policies.size)
             val prevKey = resolvePreviousKey(response, page)
 
+            notifyMetadata(response, page)
+
             LoadResult.Page(
                 data = policies,
-                prevKey = prevKey,
-                nextKey = nextKey
+                prevKey = if (manualNavigation) null else prevKey,
+                nextKey = if (manualNavigation) null else nextKey
             )
+        } catch (ioException: IOException) {
+            // Errores de red (sin conexión, timeouts, etc.).
+            LoadResult.Error(ioException)
+        } catch (httpException: HttpException) {
+            // Errores HTTP (4xx, 5xx) provenientes del servidor.
+            LoadResult.Error(httpException)
         } catch (exception: Exception) {
+            // Cualquier otra excepción inesperada.
             LoadResult.Error(exception)
         }
     }
@@ -43,20 +65,20 @@ class PoliciesPagingSource(
         currentPage: Int,
         currentSize: Int
     ): Int? {
+        // Si el backend envía el link "next", obtenemos el número de página directamente desde la URL.
         parsePageFromLink(response.next)?.let { return it }
 
-        response.count?.let { total ->
-            val totalPages = if (pageSize == 0) 0 else (total + pageSize - 1) / pageSize
-            if (totalPages != 0 && currentPage >= totalPages) {
-                return null
-            }
-        }
+        // Como respaldo, verificamos si aún hay elementos para cargar.
+        if (currentSize == 0) return null
 
-        return if (currentSize == 0) null else currentPage + 1
+        return currentPage + 1
     }
 
     private fun resolvePreviousKey(response: PolicyPagedResponse, currentPage: Int): Int? {
+        // Intentamos leer la página previa directamente desde el enlace "previous".
         parsePageFromLink(response.previous)?.let { return it }
+
+        // Si no existe enlace previo, significa que estamos en la primera página.
         return if (currentPage == FIRST_PAGE) null else currentPage - 1
     }
 
@@ -67,7 +89,35 @@ class PoliciesPagingSource(
         }.getOrNull()
     }
 
+    /**
+     * Informa a la capa superior sobre el estado de la página actual (totales y enlaces).
+     */
+    private fun notifyMetadata(
+        response: PolicyPagedResponse,
+        currentPage: Int
+    ) {
+        val totalCount = response.count ?: 0
+        val totalPages = calculateTotalPages(totalCount)
+        val hasNext = !response.next.isNullOrBlank()
+        val hasPrevious = !response.previous.isNullOrBlank() || currentPage > FIRST_PAGE
+
+        onPageMetadata(
+            PoliciesPageMetadata(
+                currentPage = currentPage,
+                totalPages = totalPages,
+                totalCount = totalCount,
+                hasPrevious = hasPrevious,
+                hasNext = hasNext
+            )
+        )
+    }
+
+    private fun calculateTotalPages(totalCount: Int): Int {
+        if (pageSize <= 0) return FIRST_PAGE
+        return max(FIRST_PAGE, (totalCount + pageSize - 1) / pageSize)
+    }
+
     companion object {
-        private const val FIRST_PAGE = 1
+        const val FIRST_PAGE = 1
     }
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/model/PoliciesRepository.kt
@@ -23,13 +23,32 @@ import javax.inject.Inject
  * www.alainnicolastello.com
  ***/
 class PoliciesRepository @Inject constructor(private val dataSource: DataSource) : BaseRepository() {
-    fun getPolicies(token: String): Flow<PagingData<Policy>> {
+    /**
+     * Expone un [Flow] de [PagingData] para consumir las pólizas de forma paginada.
+     *
+     * @param token Token de autenticación con prefijo "Bearer" listo para ser enviado en el header.
+     */
+    fun getPolicies(
+        token: String,
+        initialPage: Int = PoliciesPagingSource.FIRST_PAGE,
+        manualNavigation: Boolean = false,
+        onPageMetadata: (PoliciesPageMetadata) -> Unit = {}
+    ): Flow<PagingData<Policy>> {
         return Pager(
             config = PagingConfig(
                 pageSize = PAGE_SIZE,
                 enablePlaceholders = false
             ),
-            pagingSourceFactory = { PoliciesPagingSource(dataSource, token, PAGE_SIZE) }
+            initialKey = initialPage,
+            pagingSourceFactory = {
+                PoliciesPagingSource(
+                    dataSource = dataSource,
+                    token = token,
+                    pageSize = PAGE_SIZE,
+                    manualNavigation = manualNavigation,
+                    onPageMetadata = onPageMetadata
+                )
+            }
         ).flow
     }
 

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/view/PoliciesFragment.kt
@@ -19,6 +19,7 @@ import com.cursosant.insurance.common.utils.Constants
 import com.cursosant.insurance.common.utils.NavUtils
 import com.cursosant.insurance.common.utils.UiUtils
 import com.cursosant.insurance.databinding.FragmentPoliciesBinding
+import com.cursosant.insurance.policiesModule.model.PoliciesPagingSource
 import com.cursosant.insurance.policiesModule.view.adapters.OnClickListener
 import com.cursosant.insurance.policiesModule.view.adapters.PolicyAdapter
 import com.cursosant.insurance.policiesModule.viewModel.PoliciesViewModel
@@ -28,14 +29,18 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class PoliciesFragment : Fragment(), OnClickListener{
+class PoliciesFragment : Fragment(), OnClickListener {
 
     private var _binding: FragmentPoliciesBinding? = null
     private val binding get() = _binding!!
 
+    private val viewModel: PoliciesViewModel by viewModels()
+
     @Inject lateinit var adapter: PolicyAdapter
     @Inject lateinit var utils: UiUtils
     @Inject lateinit var navUtils: NavUtils
+
+    private var lastKnownPage = PoliciesPagingSource.FIRST_PAGE
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -56,9 +61,8 @@ class PoliciesFragment : Fragment(), OnClickListener{
     }
 
     private fun setupViewModel() {
-        val vm: PoliciesViewModel by viewModels()
         binding.lifecycleOwner = viewLifecycleOwner
-        binding.setVariable(BR.viewModel, vm)
+        binding.setVariable(BR.viewModel, viewModel)
     }
 
     private fun setupRecyclerView() {
@@ -70,22 +74,37 @@ class PoliciesFragment : Fragment(), OnClickListener{
     }
 
     private fun setupObservers() {
-        binding.viewModel?.let { vm ->
-            vm.snackbarMsg.observe(viewLifecycleOwner) { resMsg ->
+        viewModel.run {
+            snackbarMsg.observe(viewLifecycleOwner) { resMsg ->
                 utils.snackbarLong(binding.root, resMsg)
             }
-            vm.policies.observe(viewLifecycleOwner) { result ->
+            policies.observe(viewLifecycleOwner) { result ->
                 adapter.submitData(viewLifecycleOwner.lifecycle, result)
+            }
+            paginationState.observe(viewLifecycleOwner) { state ->
+                binding.btnPrevious.isEnabled = state.hasPrevious
+                binding.btnNext.isEnabled = state.hasNext
+                binding.paginationSummary.text = getString(
+                    R.string.policies_pagination_summary,
+                    state.currentPage,
+                    state.totalPages,
+                    state.totalCount
+                )
+
+                if (lastKnownPage != state.currentPage) {
+                    lastKnownPage = state.currentPage
+                    binding.recyclerView.scrollToPosition(0)
+                }
             }
 
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     adapter.loadStateFlow.collectLatest { loadState ->
                         val refreshState = loadState.refresh
-                        vm.updateLoading(refreshState is LoadState.Loading)
+                        updateLoading(refreshState is LoadState.Loading)
 
                         if (refreshState is LoadState.Loading) {
-                            vm.setPoliciesEmpty(false)
+                            setPoliciesEmpty(false)
                         }
 
                         val errorState = refreshState as? LoadState.Error
@@ -94,13 +113,13 @@ class PoliciesFragment : Fragment(), OnClickListener{
 
                         if (errorState != null) {
                             if (adapter.itemCount == 0) {
-                                vm.setPoliciesEmpty(true)
+                                setPoliciesEmpty(true)
                                 binding.retryContainer.msg = getString(R.string.policies_error)
                             }
-                            vm.notifyPoliciesError()
+                            notifyPoliciesError()
                         } else {
                             val isListEmpty = refreshState is LoadState.NotLoading && adapter.itemCount == 0
-                            vm.setPoliciesEmpty(isListEmpty)
+                            setPoliciesEmpty(isListEmpty)
                             if (isListEmpty) {
                                 binding.retryContainer.msg = getString(R.string.policies_empty_msg)
                             }
@@ -113,6 +132,8 @@ class PoliciesFragment : Fragment(), OnClickListener{
 
     private fun setupButtons() {
         binding.retryContainer.btnRetry.setOnClickListener { adapter.retry() }
+        binding.btnPrevious.setOnClickListener { viewModel.goToPreviousPage() }
+        binding.btnNext.setOnClickListener { viewModel.goToNextPage() }
     }
 
     override fun onResume() {
@@ -121,7 +142,7 @@ class PoliciesFragment : Fragment(), OnClickListener{
     }
 
     private fun getPolicies() {
-        User.instance?.let { binding.viewModel?.getPolicies(it.token.token) }
+        User.instance?.let { viewModel.getPolicies(it.token.token) }
     }
 
     override fun onDestroyView() {

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/java/com/cursosant/insurance/policiesModule/viewModel/PoliciesViewModel.kt
@@ -8,6 +8,8 @@ import androidx.paging.cachedIn
 import com.cursosant.insurance.R
 import com.cursosant.insurance.common.entities.Policy
 import com.cursosant.insurance.common.viewModel.BaseViewModel
+import com.cursosant.insurance.policiesModule.model.PoliciesPageMetadata
+import com.cursosant.insurance.policiesModule.model.PoliciesPagingSource
 import com.cursosant.insurance.policiesModule.model.PoliciesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -37,18 +39,20 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
     private val _isPoliciesEmpty = MutableLiveData(false)
     val isPoliciesEmpty: LiveData<Boolean> = _isPoliciesEmpty
 
-    private var fetchJob: Job? = null
+    private val _paginationState = MutableLiveData(PaginationUiState())
+    val paginationState: LiveData<PaginationUiState> = _paginationState
 
-    fun getPolicies(token: String) {
-        fetchJob?.cancel()
-        _isPoliciesEmpty.postValue(false)
-        fetchJob = viewModelScope.launch {
-            repository.getPolicies(token)
-                .cachedIn(viewModelScope)
-                .collectLatest { pagingData ->
-                    _policies.postValue(pagingData)
-                }
-        }
+    private var fetchJob: Job? = null
+    private var authToken: String? = null
+
+    /**
+     * Inicia o reinicia la carga paginada de pólizas fijando la página actual en [page].
+     * El resultado se expone como [LiveData] para que el fragmento lo observe y envíe
+     * cada página al adapter mediante `adapter.submitData(lifecycle, data)`.
+     */
+    fun getPolicies(token: String, page: Int = PoliciesPagingSource.FIRST_PAGE) {
+        authToken = token
+        loadPage(page)
     }
 
     fun setPoliciesEmpty(isEmpty: Boolean) {
@@ -62,4 +66,75 @@ class PoliciesViewModel @Inject constructor(private val repository: PoliciesRepo
     fun notifyPoliciesError() {
         showMsg(R.string.policies_error)
     }
+
+    /**
+     * Solicita la página siguiente cuando el backend indica que existe un enlace "next".
+     */
+    fun goToNextPage() {
+        val state = _paginationState.value ?: return
+        if (state.hasNext) {
+            loadPage(state.currentPage + 1)
+        }
+    }
+
+    /**
+     * Recupera la página anterior siempre que no estemos en la primera.
+     */
+    fun goToPreviousPage() {
+        val state = _paginationState.value ?: return
+        if (state.hasPrevious) {
+            loadPage((state.currentPage - 1).coerceAtLeast(PoliciesPagingSource.FIRST_PAGE))
+        }
+    }
+
+    /**
+     * Ejecuta la llamada Retrofit por medio del repositorio forzando que Paging solo entregue
+     * los registros de la página solicitada (sin scroll infinito).
+     */
+    private fun loadPage(page: Int) {
+        val token = authToken ?: return
+        fetchJob?.cancel()
+        _isPoliciesEmpty.postValue(false)
+        fetchJob = viewModelScope.launch {
+            repository.getPolicies(
+                token = token,
+                initialPage = page,
+                manualNavigation = true,
+                onPageMetadata = ::onPageMetadata
+            )
+                .cachedIn(viewModelScope)
+                .collectLatest { pagingData ->
+                    _policies.postValue(pagingData)
+                }
+        }
+    }
+
+    /**
+     * Transforma los metadatos de la respuesta en un estado observable para la UI.
+     */
+    private fun onPageMetadata(metadata: PoliciesPageMetadata) {
+        val currentPage = metadata.currentPage.coerceAtLeast(PoliciesPagingSource.FIRST_PAGE)
+        val totalPages = metadata.totalPages.coerceAtLeast(PoliciesPagingSource.FIRST_PAGE)
+
+        _paginationState.postValue(
+            PaginationUiState(
+                currentPage = currentPage,
+                totalPages = totalPages,
+                totalCount = metadata.totalCount,
+                hasPrevious = currentPage > PoliciesPagingSource.FIRST_PAGE,
+                hasNext = metadata.hasNext
+            )
+        )
+    }
+
+    /**
+     * Estado observable de la paginación visual.
+     */
+    data class PaginationUiState(
+        val currentPage: Int = PoliciesPagingSource.FIRST_PAGE,
+        val totalPages: Int = PoliciesPagingSource.FIRST_PAGE,
+        val totalCount: Int = 0,
+        val hasPrevious: Boolean = false,
+        val hasNext: Boolean = false
+    )
 }

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/fragment_policies.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/layout/fragment_policies.xml
@@ -17,9 +17,56 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:clipToPadding="false"
+            android:paddingBottom="16dp"
+            app:layout_constraintBottom_toTopOf="@id/paginationContainer"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             tools:listitem="@layout/item_policy"/>
+
+        <LinearLayout
+            android:id="@+id/paginationContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:padding="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnPrevious"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:text="@string/policies_pagination_previous" />
+
+            <TextView
+                android:id="@+id/paginationSummary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/policies_pagination_summary_placeholder"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnNext"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:text="@string/policies_pagination_next" />
+
+        </LinearLayout>
 
         <include
             layout="@layout/progress_full_screen"

--- a/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/strings.xml
+++ b/EGA_MEXICO/courseAndroid/EGAMXICO/XIvan/Library/Insurance/src/main/res/values/strings.xml
@@ -193,6 +193,10 @@
     <string name="insurers_error">No se encontraron aseguradoras.</string>
 
     <string name="policies_error">No se encontraron pólizas</string>
+    <string name="policies_pagination_previous">Anterior</string>
+    <string name="policies_pagination_next">Siguiente</string>
+    <string name="policies_pagination_summary">Página %1$d de %2$d · %3$d pólizas</string>
+    <string name="policies_pagination_summary_placeholder">Página 1 de 1 · 0 pólizas</string>
 
     <string name="policy_detail_btn_share">Compartir</string>
     <string name="policy_detail_btn_edit">Editar</string>


### PR DESCRIPTION
## Summary
- surface pagination metadata from the policies paging source so the UI knows the active page and total count
- expose manual page navigation actions in the repository, ViewModel, and fragment to drive Retrofit requests page by page
- render a Material footer in the policies layout with previous/next buttons and a dynamic "Página X de Y" summary

## Testing
- `./gradlew :XIvan:Library:Insurance:compileDebugKotlin` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68f17199661c832aa6b31230bc596147